### PR TITLE
Mergin code to deployment 

### DIFF
--- a/.github/workflows/BuildServer.yml
+++ b/.github/workflows/BuildServer.yml
@@ -1,16 +1,17 @@
 name: Deploy to DigitalOcean
 on:
-  workflow_dispatch:   
-  push:              
-    branches: ["master"]
+  workflow_dispatch:
+  push:
+    branches: [ "master" ]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, '[deploy]') || contains(github.event.head_commit.message, '[build]')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Run SSH commands on DigitalOcean
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -22,5 +23,26 @@ jobs:
             cd BetweenUsServer/
             ls -la
             docker compose down 
+            git pull origin master
+            docker compose up --build -d
+
+  clean_deploy:
+    runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, '[clean]')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run SSH commands on DigitalOcean
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{secrets.SSH_HOST}}
+          username: root
+          password: ${{ secrets.SSH_PASSWORD }}
+          script: |
+            echo "Connected to DigitalOcean!"
+            cd BetweenUsServer/
+            ls -la
+            docker compose down --rmi all --volumes
             git pull origin master
             docker compose up --build -d

--- a/src/main/kotlin/config/api_config/RoutesPath.kt
+++ b/src/main/kotlin/config/api_config/RoutesPath.kt
@@ -17,7 +17,8 @@ sealed class AuthRoutes(val path: String) {
 
 sealed class PersonalChatRoutes(val path: String) {
     object CreateChat : PersonalChatRoutes("$BASE_REST_PATH/personal-chats/create")
-    object GetAllChats : PersonalChatRoutes("$BASE_WP_PATH/personal-chats/get-all")
+    object GetChats : PersonalChatRoutes("$BASE_REST_PATH/personal-chats")
+    object WatchPersonalChats : PersonalChatRoutes("$BASE_WP_PATH/watch/personal-chats")
 }
 
 

--- a/src/main/kotlin/database/mongodb/repository/PersonChatRepository.kt
+++ b/src/main/kotlin/database/mongodb/repository/PersonChatRepository.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.Flow
 interface PersonChatRepository {
     suspend fun createChat(model: PersonalChatRoom): String
 
-    suspend fun getInitialPersonalChats(
+    suspend fun getChats(
         userID: String,
         paginationRequest: PaginationRequest
     ): PaginatedResponse<PersonalChatRoom>

--- a/src/main/kotlin/database/mongodb/repository/impl/PersonChatRepositoryImp.kt
+++ b/src/main/kotlin/database/mongodb/repository/impl/PersonChatRepositoryImp.kt
@@ -88,7 +88,7 @@ class PersonChatRepositoryImp(
         return PaginatedResponse(chatRooms, paginationInfo)
     }
 
-    override suspend fun getInitialPersonalChats(
+    override suspend fun getChats(
         userID: String,
         paginationRequest: PaginationRequest
     ): PaginatedResponse<PersonalChatRoom> {

--- a/src/main/kotlin/websocket/cm/PersonChatRoomConnectionManager.kt
+++ b/src/main/kotlin/websocket/cm/PersonChatRoomConnectionManager.kt
@@ -107,7 +107,7 @@ class PersonChatRoomConnectionManager @Inject constructor(
         session: WebSocketSession
     ) {
         try {
-            val chatRooms = repository.getInitialPersonalChats(userId, paginationRequest)
+            val chatRooms = repository.getChats(userId, paginationRequest)
             val message = WebSocketMessage(
                 type = WebSocketEventSendingDataType.INITIAL_DATA,
                 data = ChatRoomsUpdateData(chatRooms)
@@ -212,7 +212,7 @@ class PersonChatRoomConnectionManager @Inject constructor(
             if (connections.containsKey(userId)) {
                 try {
                     val paginationRequest = userPaginationSettings[userId] ?: PaginationRequest()
-                    val userChatRooms = repository.getInitialPersonalChats(userId, paginationRequest)
+                    val userChatRooms = repository.getChats(userId, paginationRequest)
                     broadcastToUser(
                         userId,
                         WebSocketEventSendingDataType.UPDATE_DATA,


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the personal chat API and deployment workflow. The main changes include adding a new REST endpoint for retrieving paginated personal chats, updating the chat repository for better pagination and sorting, and enhancing deployment automation with new workflow conditions and secrets usage.

**API and Repository Changes**

* Added a new REST endpoint `GET /personal-chats/{userId}` for fetching paginated personal chats, including authentication and error handling (`src/main/kotlin/routes/PersonalChatRoutes.kt`, `RoutesPath.kt`). [[1]](diffhunk://#diff-958ef62cfc8432625764521018b84a131456be5e73a4f79f0a80d0e8c10f906dR31-R115) [[2]](diffhunk://#diff-5f294ea4d06667aa146513d36f390228ab3381b16da83a5f9f3f1c158823c52aL20-R21)
* Refactored `PersonChatRepository` and its implementation:
  - Renamed `getInitialPersonalChats` to `getChats` throughout the codebase. [[1]](diffhunk://#diff-2595b0ee411625def70c200e4636c42b6cdb3385a8a4c8af695e86c1cdcce698L22-R22) [[2]](diffhunk://#diff-9b5652b7f1ab49218d6ec81d3c9ef88699e48d1886ae46c72ef6b8f571877eadL91-R98) [[3]](diffhunk://#diff-9bf1bb30ace576df959fcbb1f325f3390ccae474f099dc08cc727b0cba354b59L110-R110) [[4]](diffhunk://#diff-9bf1bb30ace576df959fcbb1f325f3390ccae474f099dc08cc727b0cba354b59L215-R215)
  - Improved pagination logic to consistently use `limit` and sort chats by `lastMessageTime` descending.
  - Added required imports for sorting.

**Deployment Workflow Enhancements**

* Updated the GitHub Actions workflow to:
  - Trigger deploy jobs only if the commit message contains `[deploy]` or `[build]`.
  - Use secrets for the SSH host instead of hardcoding the IP address.
  - Add a new `clean_deploy` job triggered by `[clean]` in the commit message, which performs a full Docker cleanup and redeploy.

These changes improve the maintainability and usability of the personal chat API and make deployment automation more secure and flexible.